### PR TITLE
#11 Add contents permission to Issues reminder workflow

### DIFF
--- a/.github/workflows/issuesAlert.yaml
+++ b/.github/workflows/issuesAlert.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: read
+      content: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR adds the `contents: read` permission to the workflow to allow checkout of the repository.