### PR TITLE
#11 Fix permission name typo

### DIFF
--- a/.github/workflows/issuesAlert.yaml
+++ b/.github/workflows/issuesAlert.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: read
-      content: read
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR fixes a typo on the `contents` token permission.