### PR TITLE
Add maintainers list

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -40,6 +40,8 @@ Selection and Removal:
 - New Maintainers are nominated by existing Maintainers and must be approved by consensus.
 - A Maintainer may be removed for inactivity, misconduct, or loss of trust by a two-thirds Maintainer vote.
 
+The current and historical list of Maintainers can be found in the [`maintainers.md`](./maintainers.md) file.
+
 ### 4.3 Steering Committee
 
 The Steering Committee oversees project governance, handles escalated decisions, and maintains legal and organizational alignment.
@@ -54,6 +56,8 @@ Composition and Terms:
 - Composed of 5–9 individuals including Maintainers and active Contributors.
 - Members serve 1-year renewable terms.
 - Elections are held annually via Contributor vote.
+
+The current and historical list of Steering Committee members can be found in the [`steering_committee.md`](./steering_committee.md) file.
 
 ## 5. Decision-Making
 

--- a/maintainers.md
+++ b/maintainers.md
@@ -1,7 +1,9 @@
-# Steering Committee
+# Maintainers
 
-## Current Steering Committee Members As of 31st of March 2025
+## Current Maintainers As of 15th of September 2025
 
+- [Mitch Gaffigan](https://github.com/mgaffigan)
+- [Nico Piel](https://github.com/nicopiel)
 - [Chris Gibson](https://github.com/gibson9583)
 - [Jonathan Bartels](https://github.com/jonbartels/)
 - [Kaur Palang](https://github.com/kpalang/)
@@ -14,10 +16,9 @@
 
 ## Historical compositions
 
-### Steering Committee As of 26th of March 2025
+### Maintainers As of 26th of March 2025
 
 - Jonathan Bartels
 - Kaur Palang
 - Paul Coyne
 - Tony Germano
-

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ The Open Integration Engine project is stewarded by a non-profit organization wi
 
 - [`governance.md`](governance.md): Defines the governance structure, decision-making processes, roles (Contributors, Maintainers, Steering Committee), licensing, and funding guidelines.
 - [`steering_committee.md`](steering_committee.md): Lists current and historical members of the Steering Committee and Maintainers.
+- [`maintainers.md`](maintainers.md): Lists current and historical Maintainers of the project.
 - [`assets.md`](assets.md): Describes project assets such as domain names, GitHub organization, Docker Hub account, and their intended ownership transfers.
 - [`vendors.md`](vendors.md): Describes the policy for being listed as a vendor offering services related to Open Integration Engine
 


### PR DESCRIPTION
Add maintainers list. Update maintainers and SC with links. Add links to governance document.

On approval, users in the maintainers list will be granted permission to approve PRs in the `engine` repo and other technical repositories. 

