### PR TITLE
Add Nico Piel as maintainer

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -1,7 +1,8 @@
 # Maintainers
 
-## Current Maintainers As of 5th of September 2025
+## Current Maintainers As of 29th of September 2025
 
+- [Nico Piel](https://github.com/nicopiel)
 - [Mitch Gaffigan](https://github.com/mgaffigan)
 - [Chris Gibson](https://github.com/gibson9583)
 - [Jonathan Bartels](https://github.com/jonbartels/)
@@ -14,6 +15,17 @@
 ---
 
 ## Historical compositions
+
+## Maintainers As of 5th of September 2025
+
+- [Mitch Gaffigan](https://github.com/mgaffigan)
+- [Chris Gibson](https://github.com/gibson9583)
+- [Jonathan Bartels](https://github.com/jonbartels/)
+- [Kaur Palang](https://github.com/kpalang/)
+- [Kiran Ayyagari](https://github.com/kayyagari)
+- [Paul Coyne](https://github.com/pacmano1)
+- [Sean Rowe](https://github.com/ssrowe)
+- [Tony Germano](https://github.com/tonygermano)
 
 ### Maintainers As of 26th of March 2025
 


### PR DESCRIPTION
This is based on PR #35 . PR #34 was split up so that we could discuss each nomination separately. 

Nico has become much more active in Discord, [PRs](https://github.com/OpenIntegrationEngine/engine/pulls?q=+is%3Apr+author%3ANicoPiel+), and [issues](https://github.com/OpenIntegrationEngine/engine/issues?q=is%3Aissue%20author%3ANicoPiel)

